### PR TITLE
Introduce default videosink/autosink options

### DIFF
--- a/gst/playback/gstplaysink.c
+++ b/gst/playback/gstplaysink.c
@@ -1770,7 +1770,10 @@ gen_video_chain (GstPlaySink * playsink, gboolean raw, gboolean async)
       /* if default sink from config.h is different then try it too */
       if (strcmp (DEFAULT_VIDEOSINK, "autovideosink")) {
         GST_DEBUG_OBJECT (playsink, "trying " DEFAULT_VIDEOSINK);
-        elem = gst_element_factory_make (DEFAULT_VIDEOSINK, "videosink");
+        if (strchr (DEFAULT_VIDEOSINK, ' ') != NULL)
+            elem = gst_parse_bin_from_description (DEFAULT_VIDEOSINK, TRUE, NULL);
+        else
+            elem = gst_element_factory_make (DEFAULT_VIDEOSINK, "videosink");
         chain->sink = try_element (playsink, elem, TRUE);
       }
     }
@@ -2713,7 +2716,10 @@ gen_audio_chain (GstPlaySink * playsink, gboolean raw)
       /* if default sink from config.h is different then try it too */
       if (strcmp (DEFAULT_AUDIOSINK, "autoaudiosink")) {
         GST_DEBUG_OBJECT (playsink, "trying " DEFAULT_AUDIOSINK);
-        elem = gst_element_factory_make (DEFAULT_AUDIOSINK, "audiosink");
+        if (strchr (DEFAULT_AUDIOSINK, ' ') != NULL)
+            elem = gst_parse_bin_from_description (DEFAULT_AUDIOSINK, TRUE, NULL);
+        else
+            elem = gst_element_factory_make (DEFAULT_AUDIOSINK, "audiosink");
         chain->sink = try_element (playsink, elem, TRUE);
       }
     }

--- a/meson.build
+++ b/meson.build
@@ -280,9 +280,8 @@ endif
 core_conf.set_quoted('GST_PACKAGE_NAME', gst_package_name)
 core_conf.set_quoted('GST_PACKAGE_ORIGIN', get_option('package-origin'))
 
-# FIXME: These should be configure options
-core_conf.set_quoted('DEFAULT_VIDEOSINK', 'autovideosink')
-core_conf.set_quoted('DEFAULT_AUDIOSINK', 'autoaudiosink')
+core_conf.set_quoted('DEFAULT_VIDEOSINK', get_option('defaultvideosink'))
+core_conf.set_quoted('DEFAULT_AUDIOSINK', get_option('defaultaudiosink'))
 
 # Set whether the audioresampling method should be detected at runtime
 core_conf.set('AUDIORESAMPLE_FORMAT_' + get_option('audioresample_format').to_upper(), true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,6 +21,11 @@ option('opengl_module_name', type : 'string', value : '',
 option('gles2_module_name', type : 'string', value : '',
        description : 'The file to pass to g_module_open to open the libGLESv2 library (default: libGLESv2)')
 
+option('defaultaudiosink', type : 'string', value : 'autoaudiosink',
+       description : 'The default audiosink')
+option('defaultvideosink', type : 'string', value : 'autovideosink',
+       description : 'The default videosink')
+
 # Feature option for opengl plugin and integration library
 option('gl', type : 'feature', value : 'auto', description : 'OpenGL integration library and OpenGL plugin')
 option('gl-graphene', type : 'feature', value : 'auto', description : 'Use Graphene in OpenGL plugin')

--- a/tools/gst-play.c
+++ b/tools/gst-play.c
@@ -205,6 +205,7 @@ play_new (gchar ** uris, const gchar * audio_sink, const gchar * video_sink,
     else
       g_warning ("Couldn't create specified audio sink '%s'", audio_sink);
   }
+
   if (video_sink != NULL) {
     if (strchr (video_sink, ' ') != NULL)
       sink = gst_parse_bin_from_description (video_sink, TRUE, NULL);
@@ -1673,6 +1674,12 @@ main (int argc, char **argv)
     g_free (playlist_file);
     playlist_file = NULL;
   }
+
+  if (audio_sink == NULL)
+    audio_sink = g_strdup(DEFAULT_AUDIOSINK);
+
+  if (video_sink == NULL)
+    video_sink = g_strdup(DEFAULT_VIDEOSINK);
 
   if (playlist->len == 0 && (filenames == NULL || *filenames == NULL)) {
     gst_printerr (_("Usage: %s FILE1|URI1 [FILE2|URI2] [FILE3|URI3] ..."),


### PR DESCRIPTION
So the end users can choose the default videosink/autosink at build time. It now supports pipeline as default videosink/autosink.