### PR TITLE
glupload: don't reject non-RGBA output format in _directviv_upload_ac…

### DIFF
--- a/gst-libs/gst/gl/gstglupload.c
+++ b/gst-libs/gst/gl/gstglupload.c
@@ -1877,10 +1877,6 @@ _directviv_upload_accept (gpointer impl, GstBuffer * buffer, GstCaps * in_caps,
 
 #if GST_GL_HAVE_PHYMEM
   GstVideoInfo *in_info = &directviv->upload->priv->in_info;
-  GstVideoFormat fmt =
-      GST_VIDEO_INFO_FORMAT (&directviv->upload->priv->out_info);
-  if (fmt != GST_VIDEO_FORMAT_RGBA)
-    return FALSE;
 
   if (n_mem != 1 || !mem || !gst_is_phys_memory (mem)) {
     GstVideoFrame frame1, frame2;
@@ -1957,9 +1953,6 @@ _directviv_upload_propose_allocation (gpointer impl, GstQuery * decide_query,
   GstCapsFeatures *caps_features;
 
   fmt = GST_VIDEO_INFO_FORMAT (&directviv->upload->priv->out_info);
-
-  if (fmt != GST_VIDEO_FORMAT_RGBA)
-    return;
 
   /* physical memory buffer pool was only proposed
    * when ion is not available to avoid allocator


### PR DESCRIPTION
…cept

In case of a more advanced sink that can support RGBA but also different YUV formats, the initial output format for the glupload element might not be RGBA. In that case, rejecting inside the upload method for the DirectVIV uploader means picking a different uploader that won't do the job properly.

If the rejecetion is removed, the upload proceeds and the pipeline is later reconfigured so that the DirectVIV uploader's RGBA-only output is respected, meaning the final sink will also move over from handling I420 to RGBA.

Upstream-Status: pending