### PR TITLE
gstallocator: Fix typcasts

### DIFF
--- a/gst-libs/gst/allocators/gstallocatorphymem.c
+++ b/gst-libs/gst/allocators/gstallocatorphymem.c
@@ -225,7 +225,7 @@ static guintptr
 gst_allocator_phymem_get_phys_addr (GstPhysMemoryAllocator * allocator,
     GstMemory * mem)
 {
-  return gst_phymem_get_phy (mem);
+  return (guintptr)gst_phymem_get_phy (mem);
 }
 
 static void

--- a/gst-libs/gst/gl/gstglphymemory.c
+++ b/gst-libs/gst/gl/gstglphymemory.c
@@ -337,7 +337,7 @@ gst_gl_physical_memory_setup_buffer (GstAllocator * allocator,
     GST_VIDEO_INFO_HEIGHT (info),
     viv_fmt,
     memblk->vaddr,
-    memblk->paddr,
+    (guint)memblk->paddr,
     FALSE
   };
 


### PR DESCRIPTION
These are found when building with clang+musl
| ../git/gst-libs/gst/allocators/gstallocatorphymem.c:228:10: error: incompatible pointer to integer conversion returning 'gpointer' (aka 'void *') from a function with result type 'guintptr ' (aka 'unsigned long') [-Wint-conversion]
|   228 |   return gst_phymem_get_phy (mem);
|       |          ^~~~~~~~~~~~~~~~~~~~~~~~